### PR TITLE
Update stickr_list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is a basic example which shows you how to find and download a sticker:
 library(stickr)
 
 # list available stickers 
-stickr_list()
+rs_stickr_list()
 
 # View the tidyverse sticker
 stickr_view("tidyverse")


### PR DESCRIPTION
It looks like the function name was changed to `rs_stickr_list`